### PR TITLE
Enable elasticsearch service.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,9 @@
   when: elasticsearch_logging_template is defined and elasticsearch_logging_template|length
   notify:
     - restart elasticsearch
+
+- name: enable elasticsearch service
+  service:
+    name: elasticsearch
+    enabled: yes
+    state: started


### PR DESCRIPTION
The elasticsearch package doesn't configure the service to start at boot. Could this task be added to do that?