### PR TITLE
Added repository for RedHat installation. Role works for RedHat, Debian ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ None.
 Role Variables
 --------------
 
-Select which version of Elasticsearch should be installed (`0.90`, `1.0` or `1.1`):
+Select which version of Elasticsearch should be installed (`0.90`, `1.0` to `1.5`):
 
-    elasticsearch_version: 1.1
+    elasticsearch_version: 1.5
 
 Select the prefered state of the package (`present` or `latest`):
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # install
 
-elasticsearch_version: 1.1
+elasticsearch_version: 1.5
 elasticsearch_state: present
 
 # elasticsearch.yml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,14 @@ galaxy_info:
   min_ansible_version: 1.4
 
   platforms:
+    - name: Redhat
+      versions:
+        - 6
+        - 7
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
     - name: Debian
       versions:
         - wheezy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,23 @@
 
 - name: add elasticsearch key
   apt_key: id=D88E42B4 url=http://packages.elasticsearch.org/GPG-KEY-elasticsearch state=present
+  when: ansible_os_family == "Debian"
 
 - name: add elasticsearch repository
   apt_repository: "repo='deb http://packages.elasticsearch.org/elasticsearch/{{ elasticsearch_version }}/debian stable main' state=present update_cache=yes"
+  when: ansible_os_family == "Debian"
 
 - name: install elasticsearch
   apt: "pkg=elasticsearch state={{ elasticsearch_state }}"
+  when: ansible_os_family == "Debian"
+
+- name: add elasticsearch repository RPM
+  template: src=repo.conf.j2 dest=/etc/yum.repos.d/elasticsearch.repo owner=root group=root mode=0644
+  when: ansible_os_family == "RedHat"
+
+- name: install elasticsearch RedHat
+  yum: pkg=elasticsearch state={{ elasticsearch_state }}
+  when: ansible_os_family == "RedHat"
 
 - name: write elasticsearch.yml
   template: src=elasticsearch.yml.j2 dest=/etc/elasticsearch/elasticsearch.yml owner=root group=root mode=0644

--- a/templates/repo.conf.j2
+++ b/templates/repo.conf.j2
@@ -1,0 +1,6 @@
+[elasticsearch-{{ elasticsearch_version }}]
+name=Elasticsearch repository for {{ elasticsearch_version }}.x packages
+baseurl=http://packages.elasticsearch.org/elasticsearch/{{ elasticsearch_version }}/centos
+gpgcheck=1
+gpgkey=http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+enabled=1


### PR DESCRIPTION
Hi,

This pull request will make sure that this role can also be used on RedHat systems. The following operating systems can be used with this role:

* RedHat
* Debian
* Ubuntu

Also updated the 1.1 value for elasticsearch_version to 1.5, as this is de latest version.

Kind regards,
Werner