### PR TITLE
Added cors configuration options to template and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,22 @@ These configuration variables are used to create `/etc/elasticsearch/elasticsear
     elasticsearch_network_host: "{{ ansible_eth0.ipv4.address }}"
     elasticsearch_transport_tcp_port: 9300
     elasticsearch_transport_tcp_compress: true
+
+    elasticsearch_http_enabled: true
     elasticsearch_http_port: 9200
     elasticsearch_http_max_content_length: 100mb
-    elasticsearch_http_enabled: true
+    elasticsearch_http_host: ~
+    elasticsearch_http_bind_host: ~
+    elasticsearch_http_publish_host: ~
+    elasticsearch_http_compression: ~
+    elasticsearch_http_compression_level: ~
+
+    elasticsearch_http_cors_enabled: false
+    elasticsearch_http_cors_allow_origin: ~
+    elasticsearch_http_cors_max_age: ~
+    elasticsearch_http_cors_allow_methods: ~
+    elasticsearch_http_cors_allow_headers: ~
+    elasticsearch_http_cors_allow_credentials: ~
 
     elasticsearch_gateway_type: local
     elasticsearch_gateway_recover_after_nodes: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,9 +33,22 @@ elasticsearch_network_publish_host: ~
 elasticsearch_network_host: "{{ ansible_eth0.ipv4.address }}"
 elasticsearch_transport_tcp_port: 9300
 elasticsearch_transport_tcp_compress: true
+
+elasticsearch_http_enabled: true
 elasticsearch_http_port: 9200
 elasticsearch_http_max_content_length: 100mb
-elasticsearch_http_enabled: true
+elasticsearch_http_host: ~
+elasticsearch_http_bind_host: ~
+elasticsearch_http_publish_host: ~
+elasticsearch_http_compression: ~
+elasticsearch_http_compression_level: ~
+
+elasticsearch_http_cors_enabled: false
+elasticsearch_http_cors_allow_origin: ~
+elasticsearch_http_cors_max_age: ~
+elasticsearch_http_cors_allow_methods: ~
+elasticsearch_http_cors_allow_headers: ~
+elasticsearch_http_cors_allow_credentials: ~
 
 elasticsearch_gateway_type: local
 elasticsearch_gateway_recover_after_nodes: 1

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -98,7 +98,7 @@ http.compression: {{ elasticsearch_http_compression }}
 http.compression_level: {{ elasticsearch_http_compression_level }}
 {% endif %}
 
-{% if http_cors_enabled %}
+{% if elasticsearch_http_cors_enabled %}
 http.cors.enabled: true
 {% if elasticsearch_http_cors_allow_origin %}
 http.cors.allow-origin: {{ elasticsearch_http_cors_allow_origin }}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -81,6 +81,44 @@ transport.tcp.compress: {{ elasticsearch_transport_tcp_compress }}
 http.enabled: true
 http.port: {{ elasticsearch_http_port }}
 http.max_content_length: {{ elasticsearch_http_max_content_length }}
+
+{% if elasticsearch_http_host %}
+http.host: {{ elasticsearch_http_host }}
+{% endif %}
+{% if elasticsearch_http_bind_host %}
+http.bind_host: {{ elasticsearch_http_bind_host }}
+{% endif %}
+{% if elasticsearch_http_publish_host %}
+http.publish_host: {{ elasticsearch_http_publish_host }}
+{% endif %}
+{% if elasticsearch_http_compression %}
+http.compression: {{ elasticsearch_http_compression }}
+{% endif %}
+{% if elasticsearch_http_compression_level %}
+http.compression_level: {{ elasticsearch_http_compression_level }}
+{% endif %}
+
+{% if http_cors_enabled %}
+http.cors.enabled: true
+{% if elasticsearch_http_cors_allow_origin %}
+http.cors.allow-origin: {{ elasticsearch_http_cors_allow_origin }}
+{% endif %}
+{% if elasticsearch_http_cors_max_age %}
+http.cors.max-age: {{ elasticsearch_http_cors_max_age }}
+{% endif %}
+{% if elasticsearch_http_cors_allow_methods %}
+http.cors.allow-methods: {{ elasticsearch_http_cors_allow_methods }}
+{% endif %}
+{% if elasticsearch_http_cors_allow_headers %}
+http.cors.allow-headers: {{ elasticsearch_http_cors_allow_headers }}
+{% endif %}
+{% if elasticsearch_http_cors_allow_credentials %}
+http.cors.allow-credentials: {{ elasticsearch_http_cors_allow_credentials }}
+{% endif %}
+{% else %}
+http.cors.enabled: false
+{% endif %}
+
 {% else %}
 http.enabled: false
 {% endif %}


### PR DESCRIPTION
The following options where added:

- `elasticsearch_http_host: ~`
- `elasticsearch_http_bind_host: ~`
- `elasticsearch_http_publish_host: ~`
- `elasticsearch_http_compression: ~`
- `elasticsearch_http_compression_level: ~`
- `elasticsearch_http_cors_enabled: false`
- `elasticsearch_http_cors_allow_origin: ~`
- `elasticsearch_http_cors_max_age: ~`
- `elasticsearch_http_cors_allow_methods: ~`
- `elasticsearch_http_cors_allow_headers: ~`
- `elasticsearch_http_cors_allow_credentials: ~`

These are not all the HTTP module settings, but sufficient to work for enabling cors. [see manual](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-http.html).