### PR TITLE
Increase minimum required Ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Install and configure Elasticsearch
   company: Future500
   license: LGPLv3
-  min_ansible_version: 1.4
+  min_ansible_version: 2.0
 
   platforms:
     - name: EL


### PR DESCRIPTION
geerlingguy.java requires Ansible 2.x: https://github.com/geerlingguy/ansible-role-java/blob/master/meta/main.yml
This is a bit problematic because Ansible 2 is only available in Debian Backports for Jessie.